### PR TITLE
add the SDK supported 4 ABI's and associated machine config's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # meta-rdk-app-sdk-base-dev
-repo for App SDK Base Layer definition &amp; development, version tracking and base layer image generation.
-
-  # how to setup and build
-  Pre-requisite : host build machine is setup for yocto kirkstone building and has google repo tool installed, see  
-  "Build host deps for yocto https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html#build-host-packages" and  
-  "install repo tool on build host https://android.googlesource.com/tools/repo "
+repo for App SDK Base Layer definition &amp; development, version tracking and base layer image generation.  
+# how to setup and build
+  #Pre-requisite : host build machine is setup for yocto kirkstone building and has google repo tool installed, see  
+  #"Build host deps for yocto https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html#build-host-packages" and  
+  #"install repo tool on build host https://android.googlesource.com/tools/repo "
 
   #Create a build directory to work in, once per "abuild" setup dir  
   mkdir abuild; cd abuild
@@ -17,18 +16,30 @@ repo for App SDK Base Layer definition &amp; development, version tracking and b
   #yocto poky build environment setup script. Once per shell you are building in  
   source oe-init-build-env
 
-  #set in local.conf DISTRO to "rdk-app-base-layer" and MACHINE config to one of supported machines  
+  #set in conf/local.conf DISTRO to "rdk-app-base-layer" and MACHINE config to one of supported machines  
   vi conf/local.conf  
-  #set  [ DISTRO ?= "rdk-app-base-layer" ] [ MACHINE = "rdk-arm" ]. Once per "abuild" setup  
+  DISTRO = "rdk-app-base-layer"  
+  #doublecheck $grep DISTRO conf/local.conf  Need to see DISTRO = "rdk-app-base-layer"  
 
-  #doublecheck $grep DISTRO conf/local.conf  Need to see DISTRO ?= "rdk-app-base-layer"  
-
+  #The App SDK supports 4 ABI's  
+  #You need to configure associated machine in conf/local.conf of your build/ dir. for example:  
+  vi conf/local.conf  
+  MACHINE = "rdk-arm32on64"  
+  #You need to select one of the following machine configurations:  
+  #1."rdk-arm" 	  - arm 32bit mode on 32bit kernel  
+  #2."rdk-arm32on64" - arm 32bit userland on 64bit kernel (so called mixed mode)  
+  #3."rdk-arm64p" 	  - arm 64bit mode (pure 64bit mode obviously with 64bit kernel, RDK is not fully supporting this yet)  
+  #4."rdk-x86_64"	  - x86 64bit mode, for running of x86 PC/virtual device  
+  #When you choose as machine "rdk-arm32on64" you need to add "lib32-" prefix when executing bitbake recipes.  
+  #For example to build base-layer image with such machine config you must use "bitbake lib32-rdke-app-baselayer-p1-oci"  
+  
   #coppy prepared bblayers.conf file from meta-rdk-app-sdk-base/manifest repo to local bblayers.conf. Once per "abuild" setup  
   cp ../.repo/manifests/manifests/bblayers.conf conf/  
 
   #build the base image, rdk-app-base-image-1 stands for profile 1 of base image.  
-  bitbake rdke-app-baselayer-p1-oci
-  
+  bitbake rdke-app-baselayer-p1-oci  
+  #or when MACHINE=rdk-arm32on64 use  
+  bitbake lib32-rdke-app-baselayer-p1-oci
 
 
   

--- a/conf/machine/rdk-arm.conf
+++ b/conf/machine/rdk-arm.conf
@@ -9,11 +9,7 @@
 #@DESCRPTION:      TODO : question what about TUNE vfpv3 versus vfpv4 ?
 
 require conf/machine/include/arm/arch-armv7a.inc 
-# OSS layer has this, why? Commmenting out, require conf/machine/include/arm/arch-arm64.inc
 DEFAULTTUNE = "armv7athf-neon"
-
-# TODO : check if needed and diff with PREFERRED_VERSION_linux-dummy ?= "5.15.%"
-# LINUXLIBCVERSION = "4.9%"
 
 #Machine overrides
 MACHINEOVERRIDES .= ":arm"
@@ -22,3 +18,5 @@ MACHINEOVERRIDES .= ":kirkstone"
 # TODO : below is in OSS config. Check if needed. Uncommenting for now 
 # MACHINEOVERRIDES .= ":client:rdkzram"
 
+# TODO : below is in OSS config. Check if needed. Uncommenting for now. check relation to PREFERRED_VERSION_linux-dummy ?= "5.15.%"
+# LINUXLIBCVERSION = "4.9%

--- a/conf/machine/rdk-arm32on64.conf
+++ b/conf/machine/rdk-arm32on64.conf
@@ -1,0 +1,25 @@
+#TYPE: Machine
+#@NAME: rdk-arm32on64
+#@DESCRIPTION: arm 32bit userland on arm 64bit kernel CPU arch ABI agreed for Applications build with RDK platform agnostic App SDK
+#@DESCRIPTION:     for 32bit userland is TUNE = "armv7vethf-neon" armv7ve with neon, thumb2, little endian  ABI and agreed specific machine
+#@DESCRIPTION:     see AVAILTUNES in https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/include/arm/arch-armv7ve.inc
+#@DESCRIPTION:     same as already defined in RDK OSS layer arch see https://github.com/rdkcentral/meta-oss-reference-development/blob/develop/conf/machine/rdk-arm64.conf#L11
+#@DESCRIPTION:     for 64bit TUNE = "armv8a-crc"
+#@DESCRIPTION:     see AVAILTUNES in https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/include/arm/arch-armv8a.inc#L12
+#@DESCRIPTION:     similar as already defined in RDK OSS layer arch see https://github.com/rdkcentral/meta-oss-reference-development/blob/develop/conf/machine/rdk-arm64.conf#L18
+
+require conf/machine/include/arm/arch-armv8a.inc
+# default tune in above arch-armv8a.inc is DEFAULTTUNE ?= "armv8a-crc"
+# assigning strict iso weak 
+DEFAULTTUNE = "armv8a-crc"
+
+# support required 32-bit ARMv7VE as multilib target
+require conf/multilib.conf
+MULTILIBS = "multilib:lib32"
+DEFAULTTUNE:virtclass-multilib-lib32 = "armv7vethf-neon"
+
+MACHINEOVERRIDES .= ":mixmode"
+DISTRO_FEATURES:append = " mixmode"
+
+# TODO : below is in OSS config. Check if needed. Uncommenting for now 
+# LINUXLIBCVERSION = "5.4%"

--- a/conf/machine/rdk-arm64p.conf
+++ b/conf/machine/rdk-arm64p.conf
@@ -1,0 +1,21 @@
+#TYPE: Machine
+#@NAME: rdk-arm64p
+#@DESCRIPTION: arm 64bit pure, both userland and kernel in 64bit CPU arch ABI agreed for Applications build with RDK platform agnostic App SDK
+#@DESCRIPTION:     for 64bit TUNE = "armv8a-crc"
+#@DESCRIPTION:     see AVAILTUNES in https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/include/arm/arch-armv8a.inc#L12
+#@DESCRPTION:      compatible with arm64-v8a as used in android  see https://developer.android.com/ndk/guides/abis#arm64-v8a NEON should be in use by DEFAULTTUNE
+
+require conf/machine/include/arm/arch-armv8a.inc
+# Primary 64-bit tune, in above arch-armv8a.inc DEFAULTTUNE ?= "armv8a-crc"  
+# uncomment below if you want force iso weak assign the DEFAULTTUNE
+DEFAULTTUNE = "armv8a-crc"
+
+# TODO Is it required to explicitly enable NEON, would think not for armv8 
+# TUNE_FEATURES += "neon"
+
+#Machine overrides
+MACHINEOVERRIDES .= ":arm64"
+MACHINEOVERRIDES .= ":kirkstone"
+
+# TODO : below is in OSS config. Check if needed. Uncommenting for now 
+# LINUXLIBCVERSION = "5.4%"

--- a/conf/machine/rdk-x86_64.conf
+++ b/conf/machine/rdk-x86_64.conf
@@ -1,0 +1,19 @@
+#TYPE: Machine
+#@NAME: rdk-x86-64
+#@DESCRIPTION: x86 64bit CPU arch ABI agreed for Applications build with RDK platform agnostic App SDK
+#@DESCRIPTION:     is TUNE = "core2-64"  based on what RDK vdevice uses. RDK vdevice uses qemux86-64
+#@DESCRIPTION:     see https://github.com/rdkcentral/meta-vdevice/blob/main/conf/machine/vdevice_x86-64.conf
+#@DESCRIPTION:     and qemux86-64 uses DEFAULTTUNE ?= "core2-64" from https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/include/x86/tune-core2.inc#L26 
+#@DESCRIPTION:     see https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/qemux86-64.conf#L12
+#@DESCRIPTION:     Android x86_64 abi supports more instruction set extensions see https://developer.android.com/ndk/guides/abis#86-64 
+#@DESCRIPTION:        and that tune config would be more like DEFAULTTUNE ?= "corei7-64" 
+#@DESCRIPTION:        see https://github.com/yoctoproject/poky/blob/kirkstone/meta/conf/machine/include/x86/tune-corei7.inc#L26
+#@DESCRIPTION:        I hear that this should be supported on PC CPU's from Intel and AMD as of 2012 so worth to switch to that after discussion and agreement
+
+require conf/machine/include/x86/tune-core2.inc
+DEFAULTTUNE = "core2-64"
+
+MACHINE_FEATURES += " x86"
+
+# TODO : below is in OSS config. Check if needed. Uncommenting for now 
+# LINUXLIBCVERSION = "5.4%"


### PR DESCRIPTION
  1."rdk-arm" 	  - arm 32bit mode on 32bit kernel
  2."rdk-arm32on64" - arm 32bit userland on 64bit kernel (so called mixed mode)
  3."rdk-arm64p" 	  - arm 64bit mode (pure 64bit mode obviously with 64bit kernel, RDK is not fully supporting this yet)
  4."rdk-x86_64"	  - x86 64bit mode, for running of x86 PC/virtual device